### PR TITLE
change ' to \" to fix layout-features not working

### DIFF
--- a/src/GlyphHangerSubset.js
+++ b/src/GlyphHangerSubset.js
@@ -113,7 +113,7 @@ class GlyphHangerSubset {
 		cmd.push( "\"" + inputFile + "\"" );
 		cmd.push( "--output-file=\"" + outputFullPath + "\"" );
 		cmd.push( "--unicodes=" + unicodes );
-		cmd.push( "--layout-features='*'" );
+		cmd.push( "--layout-features=\"*\"" );
 		if( format ) {
 			format = format.toLowerCase();
 


### PR DESCRIPTION
When running this command on my windows pc the layout-features flag is not working. 

It's not like it isn't there at all, just that it seems to be interpreted as `--layout-features=''`. 
This means that all layout features are disabled. 

I was able to make the default set work by removing the flag entirely.
If i run the command as printed in the debug log, including the "--layout-features" flag it also works fine 

I'm unsure if this a bug with shelljs or something I just don't understand but for whatever reason replacing the '' with "" makes it work as expected on my computer
 